### PR TITLE
Delete the user agent from the headers before responding

### DIFF
--- a/src/chrome-extension/background/index.js
+++ b/src/chrome-extension/background/index.js
@@ -17,7 +17,30 @@ const onNewNavigation = function onNewNavigation(details) {
   }
 };
 
+const onBeforeSendingHeaders = function onBeforeSendingHeaders(reqDetails) {
+  const { requestHeaders } = reqDetails;
+  const filteredHeaders = requestHeaders.filter(header => header.name !== 'User-Agent');
+  console.log('filtered headers', filteredHeaders);
+  return { requestHeaders: filteredHeaders };
+};
+
+// Not sure why we would we need this one but it has some interesting information.
+const onBeforeRequest = function onBeforeRequest(reqDetails) {
+  console.log('before sending the request');
+  const {
+    initiator,
+    method,
+    timeStamp,
+  } = reqDetails;
+  console.log(`${initiator}, ${method}, ${timeStamp}`);
+};
 
 // WHICH IS IT?!
 chrome.tabs.onCreated.addListener(onNewNavigation);
 // chrome.webNavigation.onDOMContentLoaded.addListener(onNewNavigation);
+
+// Remove the User-Agent from the headers of the web request
+chrome.webRequest.onBeforeSendHeaders.addListener(onBeforeSendingHeaders, { urls: ['<all_urls>'] }, ['requestHeaders']);
+
+// Uncomment next line to see information about the initiator of the web request.
+// chrome.webRequest.onBeforeRequest.addListener(onBeforeRequest, { urls: ['<all_urls>'] });

--- a/src/chrome-extension/manifest.json
+++ b/src/chrome-extension/manifest.json
@@ -5,6 +5,8 @@
     "manifest_version": 2,
     "permissions": [
       "tabs",
+      "webRequest",
+      "<all_urls>",
       "*://*/*",
       "webNavigation"
     ],
@@ -20,6 +22,6 @@
       "scripts": [
         "background/index.js"
       ],
-      "persistent": false
+      "persistent": true
     }
   }


### PR DESCRIPTION
This PR removes the "User-Agent" field from the headers. 

This is the first step of many features we could get from the [webRequest API](https://developer.chrome.com/extensions/webRequest).

Feedback and comments are welcomed 🙌 